### PR TITLE
fix shell

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,7 +34,7 @@ our %PREREQ_PM =
     'AnyEvent::Handle' => 0,
     'AnyEvent::Socket' => 0,
     'AnyEvent::Impl::Perl' => 0,
-    'IO::Pty' => 0,
+    'IO::Pty' => 1.12,
     'Term::Size' => 0,
 );
 

--- a/dan/agent/code/shell
+++ b/dan/agent/code/shell
@@ -16,6 +16,7 @@ $host ||= $ENV{TCPREMOTEIP};
 
 die "nofind user" unless my $user = $ENV{MYDan_sudo} ||  $ENV{MYDan_user};
 die "nofind user home" unless my $dir = ( getpwnam $user )[7];
+chdir $dir;
 
 warn sprintf "shell info: host:%s port:%s uuid:%s\n", map{ $_||''}$host, $port, $uuid;
 

--- a/dan/tools/shell
+++ b/dan/tools/shell
@@ -118,9 +118,12 @@ while ( $poll->handles && $soc ) {
     for my $handle ( $poll->handles( POLLIN ) ) 
     {
         my ( $data, $byte );
-	syswrite( STDOUT, $data, $byte ) 
-            if ( $handle eq $soc ) 
-            && ( $byte = sysread( $soc, $data, 1024 ) );
+        if ( $handle eq $soc )
+        {
+            if ( $byte = sysread( $soc, $data, 1024 ) ) { syswrite( STDOUT, $data, $byte ); }
+            else { $soc->shutdown(2); last; }
+        }
+
         syswrite( $soc, $data, $byte ) 
             if ( $handle eq \*STDIN )
             &&  ( $byte = sysread( STDIN, $data, 1024 ) );


### PR DESCRIPTION
'IO::Pty' => 1.12  这个如果在1.10 的时候 窗口大小的函数没有

1.设置反弹shell 登录时候 在家目录
2. 修复反弹shell 执行exit （ Ctrl-D ） 退出时候，server端发送FIN 信号之后，我们马上关闭。
之前是server 发送信号之后，我们这边一直没反应，要输入个任意键（如回车） 发送给server端
server端发送RST信号（因为之前已经关闭了） 然后client 端接受到RST 发送了进程信号才自己退出。

现在这样体验好一点